### PR TITLE
build(deps): pin Microsoft.CodeAnalysis to v5.0.0 to fix interception bug

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.0.5</VersionPrefix>
+    <VersionPrefix>1.0.6</VersionPrefix>
     <!-- SPDX license identifier for MIT -->
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <!-- Other useful metadata -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.Xunit3" Version="4.19.0" />
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.15" />
+    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.17" />
     <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.4" />
     <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.4" />
     <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.4" />
@@ -19,12 +19,12 @@
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="5.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="Scriban" Version="6.6.0"/>
+    <PackageVersion Include="Scriban" Version="7.0.0" />
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
     <PackageVersion Include="Verify.XunitV3" Version="31.13.5" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
## Summary

Downgrades `Microsoft.CodeAnalysis.Common` and `Microsoft.CodeAnalysis.CSharp` from `5.3.0` to `5.0.0` to work around a bug in the newer release that breaks source generator interception. The remaining dependency updates (`AWSSDK.DynamoDBv2`, `Scriban`) were already in the working tree and are included here. `VersionPrefix` is bumped to `1.0.6` to reflect this patch-level change.

## Changes

- `Microsoft.CodeAnalysis.Common` + `Microsoft.CodeAnalysis.CSharp`: `5.3.0` → `5.0.0` (pinned to avoid interception regression)
- `AWSSDK.DynamoDBv2`: `4.0.15` → `4.0.17`
- `Scriban`: `6.6.0` → `7.0.0`
- `VersionPrefix`: `1.0.5` → `1.0.6`

## Validation

- `dotnet build` passes with the pinned versions
- Interception-dependent code generation is unaffected at `5.0.0`

## Release Notes

Patch release `1.0.6` — pins `Microsoft.CodeAnalysis` to `5.0.0` to restore correct source generator interception behaviour broken in `5.3.0`.

## Notes for Reviewers

The `Microsoft.CodeAnalysis.Analyzers` package remains at `5.3.0` as it is a build-time-only analyzer with no runtime impact and is unaffected by the interception bug. The pin on `Common` and `CSharp` should be revisited once a fixed upstream release is available.