### PR TITLE
feat: add .NET 11 support and bump dependencies

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -22,5 +22,6 @@ jobs:
         8.0.x
         9.0.x
         10.0.x
+        11.0.x
       runCdk: false
     secrets: inherit

--- a/.github/workflows/publish-preview.yaml
+++ b/.github/workflows/publish-preview.yaml
@@ -23,5 +23,6 @@ jobs:
         8.0.x
         9.0.x
         10.0.x
+        11.0.x
       hasTests: true
     secrets: inherit

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -15,5 +15,6 @@ jobs:
         8.0.x
         9.0.x
         10.0.x
+        11.0.x
       hasTests: true
     secrets: inherit

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,24 +9,24 @@
     <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.Xunit3" Version="4.19.0" />
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.17.3" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.4" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.4" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.4" />
+    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.17.9" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.5" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.5" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.5" />
     <PackageVersion Include="Humanizer.Core" Version="3.0.10" />
     <PackageVersion Include="LayeredCraft.SourceGeneratorTools" Version="0.1.0-beta.10" />
-    <PackageVersion Include="Meziantou.Polyfill" Version="1.0.105" />
+    <PackageVersion Include="Meziantou.Polyfill" Version="1.0.110" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="5.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.202" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="Scriban" Version="7.0.6" />
+    <PackageVersion Include="Scriban" Version="7.1.0" />
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
-    <PackageVersion Include="Verify.XunitV3" Version="31.13.5" />
+    <PackageVersion Include="Verify.XunitV3" Version="31.16.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "rollForward": "latestMinor",
-    "version": "10.0.103"
+    "version": "11.0.100-preview.3.26207.106"
   },
   "test": {
     "runner": "Microsoft.Testing.Platform"

--- a/test/LayeredCraft.DynamoMapper.Generators.Tests/LayeredCraft.DynamoMapper.Generators.Tests.csproj
+++ b/test/LayeredCraft.DynamoMapper.Generators.Tests/LayeredCraft.DynamoMapper.Generators.Tests.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>
     <RootNamespace>LayeredCraft.DynamoMapper.Generators.Tests</RootNamespace>
-    <TargetFrameworks>net8.0;net10.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0;net9.0;net11.0</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <LangVersion>default</LangVersion>

--- a/test/LayeredCraft.DynamoMapper.IntegrationTests/LayeredCraft.DynamoMapper.IntegrationTests.csproj
+++ b/test/LayeredCraft.DynamoMapper.IntegrationTests/LayeredCraft.DynamoMapper.IntegrationTests.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>
     <RootNamespace>LayeredCraft.DynamoMapper.IntegrationTests</RootNamespace>
-    <TargetFrameworks>net8.0;net10.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0;net9.0;net11.0</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <LangVersion>default</LangVersion>

--- a/test/LayeredCraft.DynamoMapper.Runtime.Tests/LayeredCraft.DynamoMapper.Runtime.Tests.csproj
+++ b/test/LayeredCraft.DynamoMapper.Runtime.Tests/LayeredCraft.DynamoMapper.Runtime.Tests.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>
     <RootNamespace>LayeredCraft.DynamoMapper.Runtime.Tests</RootNamespace>
-    <TargetFrameworks>net8.0;net10.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0;net9.0;net11.0</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <LangVersion>default</LangVersion>

--- a/test/LayeredCraft.DynamoMapper.TestKit/LayeredCraft.DynamoMapper.TestKit.csproj
+++ b/test/LayeredCraft.DynamoMapper.TestKit/LayeredCraft.DynamoMapper.TestKit.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>net10.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0;net9.0;net11.0</TargetFrameworks>
     <LangVersion>default</LangVersion>
     <IsTestProject>false</IsTestProject>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary

- Add `net11.0` target framework to all test projects and `11.0.x` to all workflow `dotnetVersion` matrices
- Update `global.json` SDK to `11.0.100-preview.3.26207.106`
- Bump package versions: AWSSDK.DynamoDBv2, Basic.Reference.Assemblies (all TFMs), Scriban, Verify.XunitV3, Microsoft.NET.Test.Sdk, Microsoft.SourceLink.GitHub, Meziantou.Polyfill

---

## ✅ Checklist

- [x] My changes build cleanly
- [x] I've added/updated relevant tests
- [x] I've added/updated documentation or README
- [x] I've followed the coding style for this project
- [x] I've tested the changes locally (if applicable)

---

## 🧪 Related Issues or PRs

No blocking dependencies.

---

## 💬 Notes for Reviewers

.NET 11 is currently in preview. The SDK version in `global.json` uses `rollForward: latestMinor` so it will automatically pick up stable releases when available.