### PR TITLE
fix(generator): handle missing AssemblyInformationalVersion gracefully

### DIFF
--- a/src/LayeredCraft.DynamoMapper.Generators/Emitters/MapperEmitter.cs
+++ b/src/LayeredCraft.DynamoMapper.Generators/Emitters/MapperEmitter.cs
@@ -15,7 +15,10 @@ internal static class MapperEmitter
             {
                 var assembly = Assembly.GetExecutingAssembly();
                 var generatorName = assembly.GetName().Name;
-                var generatorVersion = assembly.GetName().Version.ToString();
+                var generatorVersion =
+                    assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                        ?.InformationalVersion ??
+                    assembly.GetName().Version?.ToString() ?? "unknown";
 
                 field =
                     $"""[global::System.CodeDom.Compiler.GeneratedCode("{generatorName}", "{generatorVersion}")]""";

--- a/test/LayeredCraft.DynamoMapper.Generators.Tests/GeneratorTestHelpers.cs
+++ b/test/LayeredCraft.DynamoMapper.Generators.Tests/GeneratorTestHelpers.cs
@@ -152,6 +152,7 @@ internal static class GeneratorTestHelpers
             );
     }
 
+
     internal static (GeneratorDriver driver, Compilation compilation) GenerateFromSource(
         CodeGenerationOptions options, CancellationToken cancellationToken = default
     )
@@ -212,6 +213,12 @@ internal static class GeneratorTestHelpers
 
 internal static partial class RegexHelper
 {
-    [GeneratedRegex("""(\d+\.\d+\.\d+\.\d+)""", RegexOptions.None, "en-US")]
+    [GeneratedRegex(
+        """
+        (?<=\")\d+\.\d+\.\d+\+[\w]*(?=\")
+        """,
+        RegexOptions.None,
+        "en-US"
+    )]
     internal static partial Regex GeneratedCodeAttributeRegex();
 }


### PR DESCRIPTION
## Summary
- Prevents `GeneratedCode` attributes from using an empty or missing version string when assembly metadata is incomplete.
- Uses informational version metadata first, then assembly version, and finally `unknown` as a safe fallback.

## Changes
- Updated generator version resolution in `MapperEmitter` to read `AssemblyInformationalVersionAttribute` before `AssemblyName.Version`.
- Added null-safe fallback chain so code generation remains stable even when version metadata is absent.

## Validation
- Ran `dotnet test --project test/LayeredCraft.DynamoMapper.Generators.Tests/LayeredCraft.DynamoMapper.Generators.Tests.csproj`.
- Current failures are snapshot mismatches in verify tests due generated `GeneratedCode` version text changing from scrubbed `REPLACED` to a concrete informational version value.