### PR TITLE
fix(build): pass VERSION arg through taskfile build and pack steps

### DIFF
--- a/.github/workflows/publish-preview.yaml
+++ b/.github/workflows/publish-preview.yaml
@@ -16,7 +16,7 @@ permissions: write-all
 
 jobs:
   publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v8.0
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@main
     with:
       solution: LayeredCraft.DynamoMapper.slnx
       dotnetVersion: |

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -2,13 +2,13 @@ name: Publish Release
 
 on:
   release:
-    types: [published]
+    types: [ published ]
 
 permissions: write-all
 
 jobs:
   publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@v8.0
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@main
     with:
       solution: LayeredCraft.DynamoMapper.slnx
       dotnetVersion: |

--- a/src/LayeredCraft.DynamoMapper.Generators/Emitters/MapperEmitter.cs
+++ b/src/LayeredCraft.DynamoMapper.Generators/Emitters/MapperEmitter.cs
@@ -15,7 +15,10 @@ internal static class MapperEmitter
             {
                 var assembly = Assembly.GetExecutingAssembly();
                 var generatorName = assembly.GetName().Name;
-                var generatorVersion = assembly.GetName().Version.ToString();
+                var generatorVersion =
+                    assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                        ?.InformationalVersion ??
+                    assembly.GetName().Version?.ToString() ?? "unknown";
 
                 field =
                     $"""[global::System.CodeDom.Compiler.GeneratedCode("{generatorName}", "{generatorVersion}")]""";

--- a/src/LayeredCraft.DynamoMapper.Generators/Emitters/MapperEmitter.cs
+++ b/src/LayeredCraft.DynamoMapper.Generators/Emitters/MapperEmitter.cs
@@ -17,8 +17,7 @@ internal static class MapperEmitter
                 var generatorName = assembly.GetName().Name;
                 var generatorVersion =
                     assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
-                        ?.InformationalVersion ??
-                    assembly.GetName().Version?.ToString() ?? "unknown";
+                        ?.InformationalVersion ?? "unknown";
 
                 field =
                     $"""[global::System.CodeDom.Compiler.GeneratedCode("{generatorName}", "{generatorVersion}")]""";

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -3,6 +3,9 @@ version: '3'
 dotenv:
   - .env
 
+vars:
+  VERSION: '{{.VERSION | default ""}}'
+
 tasks:
   format:
     desc: Reformat the solution
@@ -36,7 +39,7 @@ tasks:
     deps: [ restore ]
     cmds:
       - echo "🔨 Building Release"
-      - dotnet build --configuration Release --no-restore
+      - dotnet build --configuration Release --no-restore {{if .VERSION}}/p:Version="{{.VERSION}}"{{end}}
       - echo "✅ Release build complete"
   
   pack:
@@ -45,12 +48,14 @@ tasks:
     deps: [ build ]
     cmds:
       - echo "📦 Packing Packages"
-      - dotnet pack --configuration Release --no-build --output ./nupkg
+      - dotnet pack --configuration Release --no-build --output ./nupkg {{if .VERSION}}/p:Version="{{.VERSION}}"{{end}}
       - echo "✅ Packed"
   
   publish:
     desc: Publish the package to a package registry
     silent: true
+    requires:
+      vars: [ VERSION ]
     deps: [ pack ]
     cmds:
       - echo "🚀 Publishing"
@@ -60,6 +65,8 @@ tasks:
   pack-local:
     desc: Package and publish to local NuGet source for use in other solutions
     silent: true
+    requires:
+      vars: [ VERSION ]
     deps: [ pack ]
     vars:
       LOCAL_NUGET_SOURCE: '{{.LOCAL_NUGET_SOURCE | default "~/LocalNuGetPackages"}}'

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -58,7 +58,7 @@ tasks:
       vars: [ VERSION ]
     deps: [ pack ]
     cmds:
-      - echo "🚀 Publishing"
+      - echo "🚀 Publishing version {{.VERSION}}"
       - dotnet nuget push ./nupkg/*.nupkg --source https://api.nuget.org/v3/index.json --api-key $NUGET_API_KEY_LOCAL --skip-duplicate
       - echo "✨ Published"
   

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -71,7 +71,7 @@ tasks:
     vars:
       LOCAL_NUGET_SOURCE: '{{.LOCAL_NUGET_SOURCE | default "~/LocalNuGetPackages"}}'
     cmds:
-      - echo "📦 Publishing to local NuGet source"
+      - echo "📦 Publishing version {{.VERSION}} to local NuGet source"
       - mkdir -p {{.LOCAL_NUGET_SOURCE}}
       - cp -f ./nupkg/*.nupkg {{.LOCAL_NUGET_SOURCE}}/
       - echo "✅ Published to {{.LOCAL_NUGET_SOURCE}}"

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -62,7 +62,7 @@ tasks:
       - dotnet nuget push ./nupkg/*.nupkg --source https://api.nuget.org/v3/index.json --api-key $NUGET_API_KEY_LOCAL --skip-duplicate
       - echo "✨ Published"
   
-  pack-local:
+  publish-local:
     desc: Package and publish to local NuGet source for use in other solutions
     silent: true
     requires:

--- a/test/LayeredCraft.DynamoMapper.Generators.Tests/GeneratorTestHelpers.cs
+++ b/test/LayeredCraft.DynamoMapper.Generators.Tests/GeneratorTestHelpers.cs
@@ -152,6 +152,7 @@ internal static class GeneratorTestHelpers
             );
     }
 
+
     internal static (GeneratorDriver driver, Compilation compilation) GenerateFromSource(
         CodeGenerationOptions options, CancellationToken cancellationToken = default
     )
@@ -212,6 +213,12 @@ internal static class GeneratorTestHelpers
 
 internal static partial class RegexHelper
 {
-    [GeneratedRegex("""(\d+\.\d+\.\d+\.\d+)""", RegexOptions.None, "en-US")]
+    [GeneratedRegex(
+        """
+        (?<=\")\d+\.\d+\.\d+\+[\w]*(?=\")
+        """,
+        RegexOptions.None,
+        "en-US"
+    )]
     internal static partial Regex GeneratedCodeAttributeRegex();
 }


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary

Adds optional `VERSION` variable support to the `build` and `pack` Taskfile tasks, and makes it required for `publish` and `publish-local`. Also renames `pack-local` → `publish-local` for consistency.

- `task publish VERSION=1.0.0` and `task publish-local VERSION=1.0.0` enforce the arg via `requires`
- `task build` and `task pack` work as before without it — `/p:Version` is only injected when `VERSION` is set

---

## ✅ Checklist

- [ ] My changes build cleanly
- [ ] I've added/updated relevant tests
- [ ] I've added/updated documentation or README
- [ ] I've followed the coding style for this project
- [ ] I've tested the changes locally (if applicable)

---

## 🧪 Related Issues or PRs

> N/A

---

## 💬 Notes for Reviewers

Also includes the generator fix for `AssemblyInformationalVersion` fallback (commits `0e8f0e3`, `8af41b3`) and a regex fix for `GeneratedCodeAttribute` snapshot tests (`7078962`).