### PR TITLE
chore(deps): update devops templates and package versions

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -13,7 +13,7 @@ permissions: write-all
 jobs:
   build:
     if: github.event.pull_request.draft == false
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v8.1
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v8.2
     with:
       solution: LayeredCraft.DynamoMapper.slnx
       hasTests: true

--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   validate:
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-title-check.yml@v8.1
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-title-check.yml@v8.2

--- a/.github/workflows/publish-preview.yaml
+++ b/.github/workflows/publish-preview.yaml
@@ -16,7 +16,7 @@ permissions: write-all
 
 jobs:
   publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v8.1
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v8.2
     with:
       solution: LayeredCraft.DynamoMapper.slnx
       dotnetVersion: |

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -8,7 +8,7 @@ permissions: write-all
 
 jobs:
   publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@v8.1
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@v8.2
     with:
       solution: LayeredCraft.DynamoMapper.slnx
       dotnetVersion: |

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   draft:
-    uses: LayeredCraft/devops-templates/.github/workflows/release-drafter.yml@v8.1
+    uses: LayeredCraft/devops-templates/.github/workflows/release-drafter.yml@v8.2
     with:
       event_name: ${{ github.event_name }}
       pr_draft: ${{ github.event.pull_request.draft == true }}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,30 +5,30 @@
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="AutoFixture" Version="4.18.1"/>
-    <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1"/>
-    <PackageVersion Include="AutoFixture.Xunit3" Version="4.19.0"/>
-    <PackageVersion Include="AwesomeAssertions" Version="9.4.0"/>
-    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.17.9"/>
-    <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.5"/>
-    <PackageVersion Include="Basic.Reference.Assemblies.Net110" Version="1.8.5"/>
-    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.5"/>
-    <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.5"/>
-    <PackageVersion Include="Humanizer.Core" Version="3.0.10"/>
-    <PackageVersion Include="LayeredCraft.SourceGeneratorTools" Version="0.1.0-beta.10"/>
-    <PackageVersion Include="Meziantou.Polyfill" Version="1.0.110"/>
-    <PackageVersion Include="Microsoft.CSharp" Version="4.7.0"/>
-    <PackageVersion Include="Microsoft.CodeAnalysis" Version="5.0.0"/>
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0"/>
-    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="5.0.0"/>
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0"/>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0"/>
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.202"/>
-    <PackageVersion Include="NSubstitute" Version="5.3.0"/>
-    <PackageVersion Include="Scriban" Version="7.1.0"/>
-    <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0"/>
-    <PackageVersion Include="Verify.XunitV3" Version="31.16.1"/>
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5"/>
-    <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2"/>
+    <PackageVersion Include="AutoFixture" Version="4.18.1" />
+    <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
+    <PackageVersion Include="AutoFixture.Xunit3" Version="4.19.0" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
+    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.18.4" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.8" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net110" Version="1.8.8" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.8" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.8" />
+    <PackageVersion Include="Humanizer.Core" Version="3.0.10" />
+    <PackageVersion Include="LayeredCraft.SourceGeneratorTools" Version="0.1.0-beta.10" />
+    <PackageVersion Include="Meziantou.Polyfill" Version="1.0.131" />
+    <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="5.0.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="Scriban" Version="7.2.0" />
+    <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
+    <PackageVersion Include="Verify.XunitV3" Version="31.16.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## 📋 Summary

Updates the shared LayeredCraft devops workflow template references from `v8.1` to `v8.2` and refreshes centrally managed package versions in `Directory.Packages.props`. This keeps CI/release automation and package dependencies aligned with the latest available template and dependency updates.

## 📝 Changes

- Updated reusable GitHub workflow references for PR build, PR title validation, preview publishing, release publishing, and release drafting to `LayeredCraft/devops-templates@v8.2`.
- Refreshed central package versions for AWS SDK, Basic Reference Assemblies, Meziantou.Polyfill, Roslyn packages, test SDK, SourceLink, Scriban, and Verify.XunitV3.
- Normalized spacing in `Directory.Packages.props` package version entries.

## 🧪 Validation

- `dotnet build` succeeded.
- Build produced existing/non-blocking warnings for preview .NET SDK usage, `Microsoft.Bcl.AsyncInterfaces` version conflicts in generator tests, and obsolete example usage of `OmitNullStrings`.
