### PR TITLE
fix(deps): pin code analysis csharp to 5.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,10 +18,8 @@
     <PackageVersion Include="LayeredCraft.SourceGeneratorTools" Version="0.1.0-beta.10" />
     <PackageVersion Include="Meziantou.Polyfill" Version="1.0.131" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis" Version="5.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="[5.0.0]" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />

--- a/src/LayeredCraft.DynamoMapper.Generators/LayeredCraft.DynamoMapper.Generators.csproj
+++ b/src/LayeredCraft.DynamoMapper.Generators/LayeredCraft.DynamoMapper.Generators.csproj
@@ -52,7 +52,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" PrivateAssets="all"/>
     <PackageReference Include="Microsoft.CSharp" PrivateAssets="all"/>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all"/>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all"/>


### PR DESCRIPTION
## 📋 Summary

Pins `Microsoft.CodeAnalysis.CSharp` to `5.0.0` and removes the separate central/package reference entries for `Microsoft.CodeAnalysis` and `Microsoft.CodeAnalysis.Common`. This keeps the generator package on the intended Roslyn compiler package version after the broader dependency refresh.

## 📝 Changes

- Changed the central `Microsoft.CodeAnalysis.CSharp` package version to exact `[5.0.0]`.
- Removed unused central package versions for `Microsoft.CodeAnalysis` and `Microsoft.CodeAnalysis.Common`.
- Removed the generator project reference to `Microsoft.CodeAnalysis.Common`, relying on the CSharp package dependency graph instead.

## 🧪 Validation

- `dotnet build` succeeded.
- Build produced existing/non-blocking warnings for preview .NET SDK usage, `Microsoft.Bcl.AsyncInterfaces` version conflicts in generator tests, and obsolete example usage of `OmitNullStrings`.
