### PR TITLE
ci: upgrade devops-templates to v10.0 with NuGet trusted publishing

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -13,7 +13,7 @@ permissions: write-all
 jobs:
   build:
     if: github.event.pull_request.draft == false
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v8.2
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v10.0
     with:
       solution: LayeredCraft.DynamoMapper.slnx
       hasTests: true

--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   validate:
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-title-check.yml@v8.2
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-title-check.yml@v10.0

--- a/.github/workflows/publish-preview.yaml
+++ b/.github/workflows/publish-preview.yaml
@@ -12,11 +12,13 @@ on:
       - 'mkdocs.yml'
       - 'requirements.txt'
 
-permissions: write-all
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
-  publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v8.2
+  build:
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v10.0
     with:
       solution: LayeredCraft.DynamoMapper.slnx
       dotnetVersion: |
@@ -26,3 +28,14 @@ jobs:
         11.0.x
       hasTests: true
     secrets: inherit
+
+  push:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: LayeredCraft/devops-templates/.github/actions/nuget-push@v10.0
+        with:
+          nuget_user: ${{ secrets.NUGET_USER }}

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -4,11 +4,12 @@ on:
   release:
     types: [ published ]
 
-permissions: write-all
+permissions:
+  contents: write
 
 jobs:
-  publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@v8.2
+  build:
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@v10.0
     with:
       solution: LayeredCraft.DynamoMapper.slnx
       dotnetVersion: |
@@ -18,3 +19,14 @@ jobs:
         11.0.x
       hasTests: true
     secrets: inherit
+
+  push:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: LayeredCraft/devops-templates/.github/actions/nuget-push@v10.0
+        with:
+          nuget_user: ${{ secrets.NUGET_USER }}

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   draft:
-    uses: LayeredCraft/devops-templates/.github/workflows/release-drafter.yml@v8.2
+    uses: LayeredCraft/devops-templates/.github/workflows/release-drafter.yml@v10.0
     with:
       event_name: ${{ github.event_name }}
       pr_draft: ${{ github.event.pull_request.draft == true }}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,23 +9,23 @@
     <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.Xunit3" Version="4.19.0" />
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.18.4" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.8" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net110" Version="1.8.8" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.8" />
-    <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.8" />
+    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.21.7" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.9" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net110" Version="1.8.9" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.9" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.9" />
     <PackageVersion Include="Humanizer.Core" Version="3.0.10" />
     <PackageVersion Include="LayeredCraft.SourceGeneratorTools" Version="0.1.0-beta.10" />
-    <PackageVersion Include="Meziantou.Polyfill" Version="1.0.131" />
+    <PackageVersion Include="Meziantou.Polyfill" Version="1.0.155" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="[5.0.0]" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="Scriban" Version="7.2.0" />
+    <PackageVersion Include="Scriban" Version="7.2.5" />
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
-    <PackageVersion Include="Verify.XunitV3" Version="31.16.3" />
+    <PackageVersion Include="Verify.XunitV3" Version="31.20.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Upgrades all `devops-templates` references from `v8.2` to `v10.0` and converts the publish flows to use NuGet Trusted Publishing (OIDC) via the `nuget-push` composite action. Also includes pending package updates from `Directory.Packages.props`.

## Changes

**`publish-preview.yaml` and `publish-release.yaml`** — structural change
- Renamed `publish` job to `build`; shared template now handles build/test/pack/artifact upload only
- Added `push` job using `nuget-push@v10.0` composite action for OIDC login and NuGet push
- Tightened `permissions: write-all` to least-privilege per job

**`pr-build.yaml`, `pr-title-check.yaml`, `release-drafter.yaml`** — version bump only
- `@v8.2` → `@v10.0`, no other changes

**`Directory.Packages.props`** — package updates

## Validation

The `build` + `push` job pattern was validated end-to-end on `LayeredCraft/compact-json-formatter` with the same template version and composite action before applying here.

## Notes for Reviewers

NuGet.org trusted publisher entries for this repo will need to be configured pointing at `.github/workflows/publish-preview.yaml` and `.github/workflows/publish-release.yaml` before the push jobs will succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)