### PR TITLE
ci(github): use conventional dependabot commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
       interval: "weekly"
       day: "wednesday"
     open-pull-requests-limit: 25
+    commit-message:
+      prefix: "chore"
+      include: "scope"
     groups:
       dotnet:
         patterns:


### PR DESCRIPTION
## Summary

Configures Dependabot to generate conventional commit-style PR titles and commits for NuGet updates. This lets release-drafter autolabel Dependabot PRs using existing conventional commit title rules.

## Changes

- Added `commit-message` settings to `.github/dependabot.yml`
- Uses `chore` prefix plus Dependabot dependency scope, producing titles like `chore(deps): ...`

## Validation

- Parsed `.github/dependabot.yml` with Ruby `YAML.load_file`
- Asserted `commit-message.prefix` is `chore`
- Asserted `commit-message.include` is `scope`
